### PR TITLE
【部署】加入用 docker-compose 部署的文档

### DIFF
--- a/etc/docker-compose/README.md
+++ b/etc/docker-compose/README.md
@@ -1,0 +1,44 @@
+# README
+
+本文档描述用 docker-compose 部署 MySQL + Nginx + yzncms 的步骤。
+
+## 部署步骤
+
+1. 准备一台 Linux 主机，安装 git、docker、docker-compose 。例如 CentOS 主机可以执行以下安装命令：
+    ```sh
+    sudo su -
+    yum install -y epel-release git yum-utils python3 python3-pip
+    yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y docker-ce
+    systemctl start docker
+    systemctl enable docker
+    
+    pip3 install --upgrade pip
+    pip3 install docker-compose
+    ```
+
+2. 执行以下命令，开始部署：
+    ```sh
+    # 拉取代码
+    mkdir yzncms
+    cd yzncms
+    git clone https://github.com/ken678/yzncms.git
+
+    # 修改配置文件
+    mv yzncms/etc/docker-compose/* . 
+    sed -i "s,\('hostname'\s* => \)'127.0.0.1',\1'mysql',g"   yzncms/config/database.php
+
+    # 调整文件权限
+    mkdir -p mysql/data
+    chown -R 999 mysql
+    chown -R 1 yzncms
+
+    # 启动服务
+    docker-compose up -d
+
+    # 导入sql文件
+    sed -i '1i SET NAMES utf8; USE yzncms;'  yzncms/yzncms.sql
+    docker-compose exec -T  mysql mysql -u root --password=root < yzncms/yzncms.sql
+    ```
+
+3. 部署之后默认监听 80 端口，请访问网站 `<host>/admin/index/login.html` 。默认登录账号、密码为 admin、admin 。

--- a/etc/docker-compose/docker-compose.yml
+++ b/etc/docker-compose/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3"
+
+services:
+  mysql:
+    image: percona:5.7.34
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root     # 数据库初始密码为 root ，在 yzncms/config/database.php 中使用
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_DATABASE: yzncms
+    networks:
+      - net
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./mysql/my.cnf:/etc/my.cnf
+      - ./mysql/data:/var/lib/mysql
+
+  php-fpm:
+    image: bitnami/php-fpm:7.1
+    restart: unless-stopped
+    networks:
+      - net
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./yzncms:/app    # 在 php-fpm 和 nginx 容器中，项目文件的挂载路径必须一致，这里都为 /app
+      # - ./www.conf:/opt/bitnami/php/etc/php-fpm.d/www.conf    # 可选挂载配置文件
+
+  nginx:
+    image: nginx:1.20
+    networks:
+      - net
+    ports:
+      - 80:80
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./yzncms:/app
+
+networks:
+  net:

--- a/etc/docker-compose/mysql/my.cnf
+++ b/etc/docker-compose/mysql/my.cnf
@@ -1,0 +1,15 @@
+[mysqld]
+bind_address      = 0.0.0.0
+port              = 3306
+datadir           = /var/lib/mysql
+
+server-id         = 1                           # 启用 binlog 时，需要指定服务器的唯一 ID ，以支持主从同步
+log_bin           = '/var/lib/mysql/mysql-bin'  # 启用 binlog
+sync_binlog       = 0
+expire_logs_days  = 7                           # binlog 文件的保存天数
+
+character_set_server      = utf8mb4             # 设置服务器的默认字符集
+default_time_zone         = '+8:00'             # 设置时区，默认采用主机的时区
+default_storage_engine    = InnoDB              # 设置 MySQL 默认使用的引擎
+init_connect              = 'set names utf8mb4' # 设置一条 SQL 命令，让客户端每次建立连接时执行，从而初始化连接
+symbolic-links            = 0                   # 在数据目录中禁止使用符号链接

--- a/etc/docker-compose/nginx/nginx.conf
+++ b/etc/docker-compose/nginx/nginx.conf
@@ -1,0 +1,68 @@
+user  root;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    #tcp_nopush     on;
+    keepalive_timeout  65;
+
+    server {
+        listen 80;
+
+        root  /app/public;
+        index index.php index.html index.htm default.php default.htm default.html;
+
+        location ~ [^/]\.php(/|$) {
+            root /app/public;
+            try_files $uri =404;
+            fastcgi_pass  php-fpm:9000;
+            fastcgi_index index.php;
+
+            fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+            include fastcgi_params;
+
+            # 以下拷贝 pathinfo.conf 的内容
+            set $real_script_name $fastcgi_script_name;
+            if ($fastcgi_script_name ~ "^(.+?\.php)(/.+)$") {
+                            set $real_script_name $1;
+                            set $path_info $2;
+             }
+            fastcgi_param SCRIPT_FILENAME $document_root$real_script_name;
+            fastcgi_param SCRIPT_NAME $real_script_name;
+            fastcgi_param PATH_INFO $path_info;
+        }
+
+        # 禁止访问隐藏的文件、目录
+        location ~ /\..* {
+            return 404;
+        }
+
+        # 代理静态文件
+        location ~ ^/public/ {
+            root      /app;
+            expires   30d;
+        }
+
+        # URL重写规则引用,修改后将导致面板设置的伪静态规则失效
+        location / {
+            if (!-e $request_filename){
+                rewrite  ^(.*)$  /index.php?s=$1  last;   break;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
这个项目只推荐通过宝塔部署，不方便与流行的运维工具对接。因此我增加了容器化部署的文档。
文档路径：yzncms/etc/docker-compose/README.md